### PR TITLE
Add panic button screen

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -32,4 +32,9 @@
   "startAction": "بدء الخدمة",
   "stopAction": "إيقاف الخدمة",
   "sosAction": "إرسال SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "لضمان تتبع موثوق، يرجى تعطيل تحسين البطارية لهذا التطبيق.",
   "startAction": "بدء الخدمة",
   "stopAction": "إيقاف الخدمة",
-  "sosAction": "إرسال SOS"
+  "sosAction": "إرسال SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -32,4 +32,9 @@
   "startAction": "Inicia el servei",
   "stopAction": "Atura el servei",
   "sosAction": "Envia SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "To ensure reliable tracking, please disable battery optimization for this app.",
   "startAction": "Inicia el servei",
   "stopAction": "Atura el servei",
-  "sosAction": "Envia SOS"
+  "sosAction": "Envia SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -32,4 +32,9 @@
   "startAction": "Spustit službu",
   "stopAction": "Zastavit službu",
   "sosAction": "Odeslat SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "To ensure reliable tracking, please disable battery optimization for this app.",
   "startAction": "Spustit službu",
   "stopAction": "Zastavit službu",
-  "sosAction": "Odeslat SOS"
+  "sosAction": "Odeslat SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "Um zuverlässiges Tracking zu gewährleisten, bitte die Akkuoptimierung für diese App deaktivieren.",
   "startAction": "Dienst starten",
   "stopAction": "Dienst stoppen",
-  "sosAction": "SOS senden"
+  "sosAction": "SOS senden",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -32,4 +32,9 @@
   "startAction": "Dienst starten",
   "stopAction": "Dienst stoppen",
   "sosAction": "SOS senden"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -31,5 +31,10 @@
   "optimizationMessage": "To ensure reliable tracking, please disable battery optimization for this app.",
   "startAction": "Start service",
   "stopAction": "Stop service",
-  "sosAction": "Send SOS"
+  "sosAction": "Send SOS",
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -31,5 +31,10 @@
   "optimizationMessage": "Para garantizar un seguimiento fiable, desactive la optimización de batería para esta aplicación.",
   "startAction": "Iniciar servicio",
   "stopAction": "Detener servicio",
-  "sosAction": "Enviar SOS"
+  "sosAction": "Enviar SOS",
+  "sosSentMessage": "SOS enviado",
+  "setPasswordTitle": "Establecer contraseña",
+  "passwordPrompt": "Introducir contraseña",
+  "passwordHint": "Contraseña",
+  "invalidPassword": "Contraseña incorrecta"
 }

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -32,4 +32,9 @@
   "startAction": "شروع کار",
   "stopAction": "توقف کار",
   "sosAction": "ارسال پیام اضطراری"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "To ensure reliable tracking, please disable battery optimization for this app.",
   "startAction": "شروع کار",
   "stopAction": "توقف کار",
-  "sosAction": "ارسال پیام اضطراری"
+  "sosAction": "ارسال پیام اضطراری",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -32,4 +32,9 @@
   "startAction": "Käynnistä seuranta",
   "stopAction": "Lopeta seuranta",
   "sosAction": "Lähetä SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "Luotettavan paikannuksen varmistamiseksi, poista akun optimointi käytöstä tältä sovellukselta.",
   "startAction": "Käynnistä seuranta",
   "stopAction": "Lopeta seuranta",
-  "sosAction": "Lähetä SOS"
+  "sosAction": "Lähetä SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "Pour garantir un suivi fiable, veuillez désactiver l'optimisation de la batterie pour cette application.",
   "startAction": "Démarrer le service",
   "stopAction": "Arrêter le service",
-  "sosAction": "Envoyer un SOS"
+  "sosAction": "Envoyer un SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -32,4 +32,9 @@
   "startAction": "Démarrer le service",
   "stopAction": "Arrêter le service",
   "sosAction": "Envoyer un SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "To ensure reliable tracking, please disable battery optimization for this app.",
   "startAction": "התחל מעקב",
   "stopAction": "עצור מעקב",
-  "sosAction": "שלח SOS"
+  "sosAction": "שלח SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -32,4 +32,9 @@
   "startAction": "התחל מעקב",
   "stopAction": "עצור מעקב",
   "sosAction": "שלח SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -32,4 +32,9 @@
   "startAction": "Mulai layanan",
   "stopAction": "Hentikan layanan",
   "sosAction": "Kirim SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "Untuk memastikan pelacakan yang andal, nonaktifkan optimasi baterai untuk aplikasi ini.",
   "startAction": "Mulai layanan",
   "stopAction": "Hentikan layanan",
-  "sosAction": "Kirim SOS"
+  "sosAction": "Kirim SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -32,4 +32,9 @@
   "startAction": "Avvia servizio",
   "stopAction": "Ferma servizio",
   "sosAction": "Invia SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "Per garantire un tracciamento affidabile, disattiva l'ottimizzazione batteria per questa app.",
   "startAction": "Avvia servizio",
   "stopAction": "Ferma servizio",
-  "sosAction": "Invia SOS"
+  "sosAction": "Invia SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "To ensure reliable tracking, please disable battery optimization for this app.",
   "startAction": "サービス開始",
   "stopAction": "サービス停止",
-  "sosAction": "SOSを送信"
+  "sosAction": "SOSを送信",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -32,4 +32,9 @@
   "startAction": "サービス開始",
   "stopAction": "サービス停止",
   "sosAction": "SOSを送信"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "To ensure reliable tracking, please disable battery optimization for this app.",
   "startAction": "서비스 시작",
   "stopAction": "서비스 중지",
-  "sosAction": "SOS 전송"
+  "sosAction": "SOS 전송",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -32,4 +32,9 @@
   "startAction": "서비스 시작",
   "stopAction": "서비스 중지",
   "sosAction": "SOS 전송"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "To ensure reliable tracking, please disable battery optimization for this app.",
   "startAction": "Įjungti servisą",
   "stopAction": "Sustabdyti servisą",
-  "sosAction": "Siųsti SOS"
+  "sosAction": "Siųsti SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -32,4 +32,9 @@
   "startAction": "Įjungti servisą",
   "stopAction": "Sustabdyti servisą",
   "sosAction": "Siųsti SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -32,4 +32,9 @@
   "startAction": "Startēt servisu",
   "stopAction": "Apturēt servisu",
   "sosAction": "Sūtīt SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "To ensure reliable tracking, please disable battery optimization for this app.",
   "startAction": "Startēt servisu",
   "stopAction": "Apturēt servisu",
-  "sosAction": "Sūtīt SOS"
+  "sosAction": "Sūtīt SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -32,4 +32,9 @@
   "startAction": "Service starten",
   "stopAction": "Service stoppen",
   "sosAction": "SOS verzenden"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "Schakel batterijoptimalisatie voor deze app uit om betrouwbare tracking te garanderen.",
   "startAction": "Service starten",
   "stopAction": "Service stoppen",
-  "sosAction": "SOS verzenden"
+  "sosAction": "SOS verzenden",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "Aby zapewnić niezawodne śledzenie, wyłącz optymalizację baterii dla tej aplikacji.",
   "startAction": "Uruchom usługę",
   "stopAction": "Zatrzymaj usługę",
-  "sosAction": "Wyślij SOS"
+  "sosAction": "Wyślij SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -32,4 +32,9 @@
   "startAction": "Uruchom usługę",
   "stopAction": "Zatrzymaj usługę",
   "sosAction": "Wyślij SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "Para garantir um rastreio fiável, desative a otimização de bateria para esta aplicação.",
   "startAction": "Iniciar serviço",
   "stopAction": "Parar serviço",
-  "sosAction": "Enviar SOS"
+  "sosAction": "Enviar SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -32,4 +32,9 @@
   "startAction": "Iniciar serviço",
   "stopAction": "Parar serviço",
   "sosAction": "Enviar SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -32,4 +32,9 @@
   "startAction": "Iniciar serviço",
   "stopAction": "Parar serviço",
   "sosAction": "Enviar SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "Para garantir rastreamento confiável, desative a otimização de bateria para este aplicativo.",
   "startAction": "Iniciar serviço",
   "stopAction": "Parar serviço",
-  "sosAction": "Enviar SOS"
+  "sosAction": "Enviar SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "Чтобы обеспечить надёжное отслеживание, отключите оптимизацию батареи для этого приложения.",
   "startAction": "Запустить сервис",
   "stopAction": "Остановить сервис",
-  "sosAction": "Отправить SOS"
+  "sosAction": "Отправить SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -32,4 +32,9 @@
   "startAction": "Запустить сервис",
   "stopAction": "Остановить сервис",
   "sosAction": "Отправить SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "To ensure reliable tracking, please disable battery optimization for this app.",
   "startAction": "Zaženi storitev",
   "stopAction": "Ustavi storitev",
-  "sosAction": "Pošlji SOS"
+  "sosAction": "Pošlji SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -32,4 +32,9 @@
   "startAction": "Zaženi storitev",
   "stopAction": "Ustavi storitev",
   "sosAction": "Pošlji SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -32,4 +32,9 @@
   "startAction": "เริ่มต้นบริการ",
   "stopAction": "หยุดบริการ",
   "sosAction": "ส่ง SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "เพื่อให้การติดตามตำแหน่งทำงานได้อย่างต่อเนื่อง โปรดปิดการเพิ่มประสิทธิภาพแบตเตอรี่สำหรับแอปนี้",
   "startAction": "เริ่มต้นบริการ",
   "stopAction": "หยุดบริการ",
-  "sosAction": "ส่ง SOS"
+  "sosAction": "ส่ง SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "Güvenilir izleme için lütfen bu uygulama için pil optimizasyonunu devre dışı bırakın.",
   "startAction": "Servisi başlat",
   "stopAction": "Servisi durdur",
-  "sosAction": "SOS gönder"
+  "sosAction": "SOS gönder",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -32,4 +32,9 @@
   "startAction": "Servisi başlat",
   "stopAction": "Servisi durdur",
   "sosAction": "SOS gönder"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -32,4 +32,9 @@
   "startAction": "Запустити сервіс",
   "stopAction": "Зупинити сервіс",
   "sosAction": "Відправити SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "To ensure reliable tracking, please disable battery optimization for this app.",
   "startAction": "Запустити сервіс",
   "stopAction": "Зупинити сервіс",
-  "sosAction": "Відправити SOS"
+  "sosAction": "Відправити SOS",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "To ensure reliable tracking, please disable battery optimization for this app.",
   "startAction": "启动服务",
   "stopAction": "停止服务",
-  "sosAction": "发送求救信号"
+  "sosAction": "发送求救信号",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -32,4 +32,9 @@
   "startAction": "启动服务",
   "stopAction": "停止服务",
   "sosAction": "发送求救信号"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -32,4 +32,9 @@
   "startAction": "啟動服務",
   "stopAction": "停止服務",
   "sosAction": "發送SOS求救"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -31,7 +31,7 @@
   "optimizationMessage": "To ensure reliable tracking, please disable battery optimization for this app.",
   "startAction": "啟動服務",
   "stopAction": "停止服務",
-  "sosAction": "發送SOS求救"
+  "sosAction": "發送SOS求救",
   "sosSentMessage": "SOS sent",
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:traccar_client/quick_actions.dart';
 
 import 'l10n/app_localizations.dart';
 import 'main_screen.dart';
+import 'panic_screen.dart';
 import 'preferences.dart';
 
 void main() async {
@@ -60,7 +61,7 @@ class _MainAppState extends State<MainApp> {
       home: Stack(
         children: const [
           QuickActionsInitializer(),
-          MainScreen(),
+          PanicScreen(),
         ],
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,10 +35,44 @@ class _MainAppState extends State<MainApp> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       await rateMyApp.init();
-      if (mounted && rateMyApp.shouldOpenDialog) {  
+      if (mounted && rateMyApp.shouldOpenDialog) {
         rateMyApp.showRateDialog(context);
       }
+      await _ensurePassword();
     });
+  }
+
+  Future<void> _ensurePassword() async {
+    final current = Preferences.instance.getString(Preferences.password);
+    if (current == null || current.isEmpty) {
+      final controller = TextEditingController();
+      final result = await showDialog<String>(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: Text(AppLocalizations.of(context)!.setPasswordTitle),
+          content: TextField(
+            controller: controller,
+            obscureText: true,
+            decoration: InputDecoration(
+              hintText: AppLocalizations.of(context)!.passwordHint,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(AppLocalizations.of(context)!.cancelButton),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, controller.text),
+              child: Text(AppLocalizations.of(context)!.saveButton),
+            ),
+          ],
+        ),
+      );
+      if (result != null && result.isNotEmpty) {
+        await Preferences.instance.setString(Preferences.password, result);
+      }
+    }
   }
 
   @override

--- a/lib/panic_screen.dart
+++ b/lib/panic_screen.dart
@@ -5,19 +5,72 @@ import 'package:flutter_background_geolocation/flutter_background_geolocation.da
 
 import 'l10n/app_localizations.dart';
 import 'main_screen.dart';
+import 'preferences.dart';
 
 class PanicScreen extends StatelessWidget {
   const PanicScreen({super.key});
 
-  Future<void> _sendSos() async {
+  Future<void> _sendSos(BuildContext context) async {
     try {
       await bg.BackgroundGeolocation.getCurrentPosition(
         samples: 1,
         persist: true,
         extras: {'alarm': 'sos'},
       );
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(AppLocalizations.of(context)!.sosSentMessage)),
+        );
+      }
     } catch (error) {
       developer.log('Failed to send alert', error: error);
+    }
+  }
+
+  Future<void> _openMainScreen(BuildContext context) async {
+    final stored = Preferences.instance.getString(Preferences.password);
+    if (stored != null && stored.isNotEmpty) {
+      final controller = TextEditingController();
+      final result = await showDialog<String>(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: Text(AppLocalizations.of(context)!.passwordPrompt),
+          content: TextField(
+            controller: controller,
+            obscureText: true,
+            decoration: InputDecoration(
+              hintText: AppLocalizations.of(context)!.passwordHint,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(AppLocalizations.of(context)!.cancelButton),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, controller.text),
+              child: Text(AppLocalizations.of(context)!.okButton),
+            ),
+          ],
+        ),
+      );
+      if (result == stored) {
+        if (context.mounted) {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const MainScreen()),
+          );
+        }
+      } else if (result != null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(AppLocalizations.of(context)!.invalidPassword)),
+        );
+      }
+    } else {
+      Navigator.push(
+        context,
+        MaterialPageRoute(builder: (_) => const MainScreen()),
+      );
     }
   }
 
@@ -28,18 +81,13 @@ class PanicScreen extends StatelessWidget {
         actions: [
           IconButton(
             icon: const Icon(Icons.settings),
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => const MainScreen()),
-              );
-            },
+            onPressed: () => _openMainScreen(context),
           ),
         ],
       ),
       body: Center(
         child: FilledButton(
-          onPressed: _sendSos,
+          onPressed: () => _sendSos(context),
           child: Text(AppLocalizations.of(context)!.sosAction),
         ),
       ),

--- a/lib/panic_screen.dart
+++ b/lib/panic_screen.dart
@@ -1,0 +1,48 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_background_geolocation/flutter_background_geolocation.dart' as bg;
+
+import 'l10n/app_localizations.dart';
+import 'main_screen.dart';
+
+class PanicScreen extends StatelessWidget {
+  const PanicScreen({super.key});
+
+  Future<void> _sendSos() async {
+    try {
+      await bg.BackgroundGeolocation.getCurrentPosition(
+        samples: 1,
+        persist: true,
+        extras: {'alarm': 'sos'},
+      );
+    } catch (error) {
+      developer.log('Failed to send alert', error: error);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const MainScreen()),
+              );
+            },
+          ),
+        ],
+      ),
+      body: Center(
+        child: FilledButton(
+          onPressed: _sendSos,
+          child: Text(AppLocalizations.of(context)!.sosAction),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/preferences.dart
+++ b/lib/preferences.dart
@@ -20,6 +20,7 @@ class Preferences {
   static const String buffer = 'buffer';
   static const String wakelock = 'wakelock';
   static const String stopDetection = 'stop_detection';
+  static const String password = 'password';
 
   static const String lastTimestamp = 'lastTimestamp';
   static const String lastLatitude = 'lastLatitude';
@@ -33,11 +34,28 @@ class Preferences {
         : SharedPreferencesOptions(),
       cacheOptions: SharedPreferencesWithCacheOptions(
         allowList: {
-          id, url, accuracy, distance, interval, angle, heartbeat,
-          fastestInterval, buffer,  wakelock, stopDetection,
-          lastTimestamp, lastLatitude, lastLongitude, lastHeading,
-          'device_id_preference', 'server_url_preference', 'accuracy_preference',
-          'frequency_preference', 'distance_preference', 'buffer_preference',
+          id,
+          url,
+          accuracy,
+          distance,
+          interval,
+          angle,
+          heartbeat,
+          fastestInterval,
+          buffer,
+          wakelock,
+          stopDetection,
+          password,
+          lastTimestamp,
+          lastLatitude,
+          lastLongitude,
+          lastHeading,
+          'device_id_preference',
+          'server_url_preference',
+          'accuracy_preference',
+          'frequency_preference',
+          'distance_preference',
+          'buffer_preference',
         },
       ),
     );


### PR DESCRIPTION
## Summary
- make new `PanicScreen` with central SOS button
- open `PanicScreen` at startup
- gear icon opens the existing main screen

## Testing
- `dart` and `flutter` commands are unavailable in this environment, so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_685786730c1c8320b0e9f38c8c36eb50