### PR TITLE
Add password protection and SOS confirmation

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -32,4 +32,9 @@
   "startAction": "بدء الخدمة",
   "stopAction": "إيقاف الخدمة",
   "sosAction": "إرسال SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -32,4 +32,9 @@
   "startAction": "Inicia el servei",
   "stopAction": "Atura el servei",
   "sosAction": "Envia SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -32,4 +32,9 @@
   "startAction": "Spustit službu",
   "stopAction": "Zastavit službu",
   "sosAction": "Odeslat SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -32,4 +32,9 @@
   "startAction": "Dienst starten",
   "stopAction": "Dienst stoppen",
   "sosAction": "SOS senden"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -31,5 +31,10 @@
   "optimizationMessage": "To ensure reliable tracking, please disable battery optimization for this app.",
   "startAction": "Start service",
   "stopAction": "Stop service",
-  "sosAction": "Send SOS"
+  "sosAction": "Send SOS",
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -31,5 +31,10 @@
   "optimizationMessage": "Para garantizar un seguimiento fiable, desactive la optimización de batería para esta aplicación.",
   "startAction": "Iniciar servicio",
   "stopAction": "Detener servicio",
-  "sosAction": "Enviar SOS"
+  "sosAction": "Enviar SOS",
+  "sosSentMessage": "SOS enviado",
+  "setPasswordTitle": "Establecer contraseña",
+  "passwordPrompt": "Introducir contraseña",
+  "passwordHint": "Contraseña",
+  "invalidPassword": "Contraseña incorrecta"
 }

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -32,4 +32,9 @@
   "startAction": "شروع کار",
   "stopAction": "توقف کار",
   "sosAction": "ارسال پیام اضطراری"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -32,4 +32,9 @@
   "startAction": "Käynnistä seuranta",
   "stopAction": "Lopeta seuranta",
   "sosAction": "Lähetä SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -32,4 +32,9 @@
   "startAction": "Démarrer le service",
   "stopAction": "Arrêter le service",
   "sosAction": "Envoyer un SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -32,4 +32,9 @@
   "startAction": "התחל מעקב",
   "stopAction": "עצור מעקב",
   "sosAction": "שלח SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -32,4 +32,9 @@
   "startAction": "Mulai layanan",
   "stopAction": "Hentikan layanan",
   "sosAction": "Kirim SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -32,4 +32,9 @@
   "startAction": "Avvia servizio",
   "stopAction": "Ferma servizio",
   "sosAction": "Invia SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -32,4 +32,9 @@
   "startAction": "サービス開始",
   "stopAction": "サービス停止",
   "sosAction": "SOSを送信"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -32,4 +32,9 @@
   "startAction": "서비스 시작",
   "stopAction": "서비스 중지",
   "sosAction": "SOS 전송"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -32,4 +32,9 @@
   "startAction": "Įjungti servisą",
   "stopAction": "Sustabdyti servisą",
   "sosAction": "Siųsti SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -32,4 +32,9 @@
   "startAction": "Startēt servisu",
   "stopAction": "Apturēt servisu",
   "sosAction": "Sūtīt SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -32,4 +32,9 @@
   "startAction": "Service starten",
   "stopAction": "Service stoppen",
   "sosAction": "SOS verzenden"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -32,4 +32,9 @@
   "startAction": "Uruchom usługę",
   "stopAction": "Zatrzymaj usługę",
   "sosAction": "Wyślij SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -32,4 +32,9 @@
   "startAction": "Iniciar serviço",
   "stopAction": "Parar serviço",
   "sosAction": "Enviar SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -32,4 +32,9 @@
   "startAction": "Iniciar serviço",
   "stopAction": "Parar serviço",
   "sosAction": "Enviar SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -32,4 +32,9 @@
   "startAction": "Запустить сервис",
   "stopAction": "Остановить сервис",
   "sosAction": "Отправить SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -32,4 +32,9 @@
   "startAction": "Zaženi storitev",
   "stopAction": "Ustavi storitev",
   "sosAction": "Pošlji SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -32,4 +32,9 @@
   "startAction": "เริ่มต้นบริการ",
   "stopAction": "หยุดบริการ",
   "sosAction": "ส่ง SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -32,4 +32,9 @@
   "startAction": "Servisi başlat",
   "stopAction": "Servisi durdur",
   "sosAction": "SOS gönder"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -32,4 +32,9 @@
   "startAction": "Запустити сервіс",
   "stopAction": "Зупинити сервіс",
   "sosAction": "Відправити SOS"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -32,4 +32,9 @@
   "startAction": "启动服务",
   "stopAction": "停止服务",
   "sosAction": "发送求救信号"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -32,4 +32,9 @@
   "startAction": "啟動服務",
   "stopAction": "停止服務",
   "sosAction": "發送SOS求救"
+  "sosSentMessage": "SOS sent",
+  "setPasswordTitle": "Set password",
+  "passwordPrompt": "Enter password",
+  "passwordHint": "Password",
+  "invalidPassword": "Invalid password"
 }

--- a/lib/panic_screen.dart
+++ b/lib/panic_screen.dart
@@ -1,0 +1,96 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_background_geolocation/flutter_background_geolocation.dart' as bg;
+
+import 'l10n/app_localizations.dart';
+import 'main_screen.dart';
+import 'preferences.dart';
+
+class PanicScreen extends StatelessWidget {
+  const PanicScreen({super.key});
+
+  Future<void> _sendSos(BuildContext context) async {
+    try {
+      await bg.BackgroundGeolocation.getCurrentPosition(
+        samples: 1,
+        persist: true,
+        extras: {'alarm': 'sos'},
+      );
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(AppLocalizations.of(context)!.sosSentMessage)),
+        );
+      }
+    } catch (error) {
+      developer.log('Failed to send alert', error: error);
+    }
+  }
+
+  Future<void> _openMainScreen(BuildContext context) async {
+    final stored = Preferences.instance.getString(Preferences.password);
+    if (stored != null && stored.isNotEmpty) {
+      final controller = TextEditingController();
+      final result = await showDialog<String>(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: Text(AppLocalizations.of(context)!.passwordPrompt),
+          content: TextField(
+            controller: controller,
+            obscureText: true,
+            decoration: InputDecoration(
+              hintText: AppLocalizations.of(context)!.passwordHint,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(AppLocalizations.of(context)!.cancelButton),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, controller.text),
+              child: Text(AppLocalizations.of(context)!.okButton),
+            ),
+          ],
+        ),
+      );
+      if (result == stored) {
+        if (context.mounted) {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const MainScreen()),
+          );
+        }
+      } else if (result != null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(AppLocalizations.of(context)!.invalidPassword)),
+        );
+      }
+    } else {
+      Navigator.push(
+        context,
+        MaterialPageRoute(builder: (_) => const MainScreen()),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () => _openMainScreen(context),
+          ),
+        ],
+      ),
+      body: Center(
+        child: FilledButton(
+          onPressed: () => _sendSos(context),
+          child: Text(AppLocalizations.of(context)!.sosAction),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/preferences.dart
+++ b/lib/preferences.dart
@@ -20,6 +20,7 @@ class Preferences {
   static const String buffer = 'buffer';
   static const String wakelock = 'wakelock';
   static const String stopDetection = 'stop_detection';
+  static const String password = 'password';
 
   static const String lastTimestamp = 'lastTimestamp';
   static const String lastLatitude = 'lastLatitude';
@@ -33,11 +34,28 @@ class Preferences {
         : SharedPreferencesOptions(),
       cacheOptions: SharedPreferencesWithCacheOptions(
         allowList: {
-          id, url, accuracy, distance, interval, angle, heartbeat,
-          fastestInterval, buffer,  wakelock, stopDetection,
-          lastTimestamp, lastLatitude, lastLongitude, lastHeading,
-          'device_id_preference', 'server_url_preference', 'accuracy_preference',
-          'frequency_preference', 'distance_preference', 'buffer_preference',
+          id,
+          url,
+          accuracy,
+          distance,
+          interval,
+          angle,
+          heartbeat,
+          fastestInterval,
+          buffer,
+          wakelock,
+          stopDetection,
+          password,
+          lastTimestamp,
+          lastLatitude,
+          lastLongitude,
+          lastHeading,
+          'device_id_preference',
+          'server_url_preference',
+          'accuracy_preference',
+          'frequency_preference',
+          'distance_preference',
+          'buffer_preference',
         },
       ),
     );

--- a/lib/quick_actions.dart
+++ b/lib/quick_actions.dart
@@ -25,14 +25,17 @@ class _QuickActionsInitializerState extends State<QuickActionsInitializer> {
       switch (shortcutType) {
         case 'start':
           bg.BackgroundGeolocation.start();
+          break;
         case 'stop':
           bg.BackgroundGeolocation.stop();
+          break;
         case 'sos':
           try {
             await bg.BackgroundGeolocation.getCurrentPosition(samples: 1, persist: true, extras: {'alarm': 'sos'});
           } catch (error) {
             developer.log('Failed to send alert', error: error);
           }
+          break;
       }
       if (mounted) {
         SystemNavigator.pop();


### PR DESCRIPTION
## Summary
- show dialog to set password on first launch
- require password to open settings screen
- confirm SOS alerts with a snackbar
- fix switch cases for quick actions
- add new localization keys

## Testing
- `dart format lib/main.dart lib/panic_screen.dart lib/preferences.dart lib/quick_actions.dart` *(fails: `dart: command not found`)*
- `flutter --version` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685786730c1c8320b0e9f38c8c36eb50