### PR TITLE
Move password setup to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Traccar Client is a GPS tracking app for Android and iOS. It runs in the backgro
 
 Just enter your server address, grant location permissions, and the app will automatically send periodic location reports in the background.
 
+## Password protection
+
+You can secure access to the main screen with a password.
+
+1. Open the **Settings** screen from the gear icon or the main menu.
+2. Tap **Password** and enter a value. Leaving the field empty will remove the password.
+3. When a password is set, opening the settings from the panic screen will prompt for it.
+
 ## Team
 
 - Anton Tananaev ([anton@traccar.org](mailto:anton@traccar.org))

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -36,5 +36,6 @@
   "setPasswordTitle": "Set password",
   "passwordPrompt": "Enter password",
   "passwordHint": "Password",
+  "passwordLabel": "Password",
   "invalidPassword": "Invalid password"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -36,5 +36,6 @@
   "setPasswordTitle": "Establecer contraseña",
   "passwordPrompt": "Introducir contraseña",
   "passwordHint": "Contraseña",
+  "passwordLabel": "Contraseña",
   "invalidPassword": "Contraseña incorrecta"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,41 +38,7 @@ class _MainAppState extends State<MainApp> {
       if (mounted && rateMyApp.shouldOpenDialog) {
         rateMyApp.showRateDialog(context);
       }
-      await _ensurePassword();
     });
-  }
-
-  Future<void> _ensurePassword() async {
-    final current = Preferences.instance.getString(Preferences.password);
-    if (current == null || current.isEmpty) {
-      final controller = TextEditingController();
-      final result = await showDialog<String>(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: Text(AppLocalizations.of(context)!.setPasswordTitle),
-          content: TextField(
-            controller: controller,
-            obscureText: true,
-            decoration: InputDecoration(
-              hintText: AppLocalizations.of(context)!.passwordHint,
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(AppLocalizations.of(context)!.cancelButton),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(context, controller.text),
-              child: Text(AppLocalizations.of(context)!.saveButton),
-            ),
-          ],
-        ),
-      );
-      if (result != null && result.isNotEmpty) {
-        await Preferences.instance.setString(Preferences.password, result);
-      }
-    }
   }
 
   @override

--- a/lib/settings_screen.dart
+++ b/lib/settings_screen.dart
@@ -99,6 +99,48 @@ class _SettingsScreenState extends State<SettingsScreen> {
     }
   }
 
+  Future<void> _editPassword(String title) async {
+    final controller = TextEditingController(
+      text: Preferences.instance.getString(Preferences.password) ?? '',
+    );
+    final result = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(title),
+        content: TextField(
+          controller: controller,
+          obscureText: true,
+          decoration: InputDecoration(
+            hintText: AppLocalizations.of(context)!.passwordHint,
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text(AppLocalizations.of(context)!.cancelButton),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, controller.text),
+            child: Text(AppLocalizations.of(context)!.saveButton),
+          ),
+        ],
+      ),
+    );
+    if (result != null) {
+      await Preferences.instance.setString(Preferences.password, result);
+      setState(() {});
+    }
+  }
+
+  Widget _buildPasswordTile() {
+    final stored = Preferences.instance.getString(Preferences.password);
+    return ListTile(
+      title: Text(AppLocalizations.of(context)!.passwordLabel),
+      subtitle: Text(stored != null && stored.isNotEmpty ? '••••••' : ''),
+      onTap: () => _editPassword(AppLocalizations.of(context)!.setPasswordTitle),
+    );
+  }
+
   Widget _buildListTile(String title, String key, bool isInt) {
     String? value;
     if (isInt) {
@@ -153,6 +195,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         children: [
           _buildListTile(AppLocalizations.of(context)!.idLabel, Preferences.id, false),
           _buildListTile(AppLocalizations.of(context)!.urlLabel, Preferences.url, false),
+          _buildPasswordTile(),
           _buildAccuracyListTile(),
           _buildListTile(AppLocalizations.of(context)!.distanceLabel, Preferences.distance, true),
           if (isHighestAccuracy || Platform.isAndroid && distance == 0)


### PR DESCRIPTION
## Summary
- manage password via Settings screen instead of a startup dialog
- add password settings tile and localization strings
- document how to configure password protection

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68583014b4648320b96d1446af2fe3ac