### PR TITLE
Add QuickCallSection widget

### DIFF
--- a/lib/panic_screen.dart
+++ b/lib/panic_screen.dart
@@ -1,5 +1,4 @@
 import 'dart:developer' as developer;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_background_geolocation/flutter_background_geolocation.dart' as bg;
 
@@ -133,37 +132,38 @@ class _PanicScreenState extends State<PanicScreen> {
                         ),
                       ],
                     ),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: const [
-                    Icon(Icons.warning_amber_rounded, size: 64, color: Colors.white),
-                    SizedBox(height: 16),
-                    Text(
-                      'EMERGENCIA',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 32,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    SizedBox(height: 4),
-                    Opacity(
-                      opacity: 0.7,
-                      child: Text(
-                        'Mantén presionado',
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 14,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: const [
+                        Icon(Icons.warning_amber_rounded, size: 64, color: Colors.white),
+                        SizedBox(height: 16),
+                        Text(
+                          'EMERGENCIA',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 32,
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
-                      ),
+                        SizedBox(height: 4),
+                        Opacity(
+                          opacity: 0.7,
+                          child: Text(
+                            'Mantén presionado',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 14,
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
-                  ],
                   ),
                 ),
               ),
             ),
           ),
-          const SizedBox(height: 24),
+          const SizedBox(height: 24.0),
           const Padding(
             padding: EdgeInsets.symmetric(horizontal: 16),
             child: QuickCallSection(),

--- a/lib/panic_screen.dart
+++ b/lib/panic_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_background_geolocation/flutter_background_geolocation.da
 import 'l10n/app_localizations.dart';
 import 'main_screen.dart';
 import 'preferences.dart';
+import 'quick_call_section.dart';
 
 class PanicScreen extends StatefulWidget {
   const PanicScreen({super.key});
@@ -93,42 +94,45 @@ class _PanicScreenState extends State<PanicScreen> {
           ),
         ],
       ),
-      body: Center(
-        child: MouseRegion(
-          onEnter: (_) => setState(() {
-            _hovering = true;
-            _scale = 1.05;
-          }),
-          onExit: (_) => setState(() {
-            _hovering = false;
-            _scale = 1.0;
-          }),
-          child: GestureDetector(
-            onLongPress: () => _sendSos(context),
-            onTapDown: (_) => setState(() => _scale = 0.95),
-            onTapUp: (_) => setState(() => _scale = _hovering ? 1.05 : 1.0),
-            onTapCancel: () => setState(() => _scale = _hovering ? 1.05 : 1.0),
-            child: AnimatedScale(
-              scale: _scale,
-              duration: const Duration(milliseconds: 200),
-              child: Container(
-                width: 280,
-                height: 280,
-                decoration: const BoxDecoration(
-                  shape: BoxShape.circle,
-                  gradient: LinearGradient(
-                    colors: [Color(0xffef4444), Color(0xffdc2626)],
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                  ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black38,
-                      offset: Offset(0, 8),
-                      blurRadius: 20,
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Center(
+            child: MouseRegion(
+              onEnter: (_) => setState(() {
+                _hovering = true;
+                _scale = 1.05;
+              }),
+              onExit: (_) => setState(() {
+                _hovering = false;
+                _scale = 1.0;
+              }),
+              child: GestureDetector(
+                onLongPress: () => _sendSos(context),
+                onTapDown: (_) => setState(() => _scale = 0.95),
+                onTapUp: (_) => setState(() => _scale = _hovering ? 1.05 : 1.0),
+                onTapCancel: () => setState(() => _scale = _hovering ? 1.05 : 1.0),
+                child: AnimatedScale(
+                  scale: _scale,
+                  duration: const Duration(milliseconds: 200),
+                  child: Container(
+                    width: 280,
+                    height: 280,
+                    decoration: const BoxDecoration(
+                      shape: BoxShape.circle,
+                      gradient: LinearGradient(
+                        colors: [Color(0xffef4444), Color(0xffdc2626)],
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                      ),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black38,
+                          offset: Offset(0, 8),
+                          blurRadius: 20,
+                        ),
+                      ],
                     ),
-                  ],
-                ),
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: const [
@@ -154,11 +158,17 @@ class _PanicScreenState extends State<PanicScreen> {
                       ),
                     ),
                   ],
+                  ),
                 ),
               ),
             ),
           ),
-        ),
+          const SizedBox(height: 24),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16),
+            child: QuickCallSection(),
+          ),
+        ],
       ),
     );
   }

--- a/lib/quick_call_section.dart
+++ b/lib/quick_call_section.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class QuickCallSection extends StatelessWidget {
+  const QuickCallSection({Key? key}) : super(key: key);
+
+  Future<void> _callEmergency() async {
+    final Uri uri = Uri(scheme: 'tel', path: '911');
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.phone, size: 20),
+                const SizedBox(width: 8),
+                Text(
+                  'Llamada Rápida',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Toca para llamar directamente',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              height: 60,
+              child: TextButton(
+                style: ButtonStyle(
+                  backgroundColor: WidgetStateProperty.resolveWith<Color?>(
+                    (states) {
+                      if (states.contains(WidgetState.hovered)) {
+                        return const Color(0xfff9fafb);
+                      }
+                      return Colors.white;
+                    },
+                  ),
+                  shape: WidgetStateProperty.all(
+                    RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                      side: const BorderSide(color: Color(0xffd1d5db)),
+                    ),
+                  ),
+                  padding: WidgetStateProperty.all(
+                    const EdgeInsets.symmetric(horizontal: 16),
+                  ),
+                ),
+                onPressed: _callEmergency,
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.shield, color: Color(0xff2563eb), size: 20),
+                    const SizedBox(width: 12),
+                    Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: const [
+                        Text(
+                          'Emergencias',
+                          style: TextStyle(fontWeight: FontWeight.w600),
+                        ),
+                        SizedBox(height: 2),
+                        Text(
+                          '911',
+                          style: TextStyle(color: Color(0xff6b7280), fontSize: 12),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/quick_call_section.dart
+++ b/lib/quick_call_section.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class QuickCallSection extends StatelessWidget {
@@ -12,75 +11,66 @@ class QuickCallSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
     return Card(
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(16),
       ),
-      elevation: 2,
+      elevation: 4,
+      color: isDark ? const Color(0xff1f2937) : const Color(0xfff9fafb),
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(20),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Row(
               children: [
-                const Icon(Icons.phone, size: 20),
+                Icon(Icons.phone, size: 24, color: isDark ? Colors.white : Colors.black87),
                 const SizedBox(width: 8),
                 Text(
                   'Llamada Rápida',
-                  style: Theme.of(context).textTheme.titleMedium,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: isDark ? Colors.white : Colors.black87,
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
               ],
             ),
-            const SizedBox(height: 4),
+            const SizedBox(height: 6),
             Text(
-              'Toca para llamar directamente',
-              style: Theme.of(context).textTheme.bodySmall,
+              'Toca para llamar directamente al 911.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: isDark ? Colors.grey[300] : Colors.grey[700],
+              ),
             ),
-            const SizedBox(height: 12),
+            const SizedBox(height: 16),
             SizedBox(
               width: double.infinity,
-              height: 60,
-              child: TextButton(
-                style: ButtonStyle(
-                  backgroundColor: WidgetStateProperty.resolveWith<Color?>(
-                    (states) {
-                      if (states.contains(WidgetState.hovered)) {
-                        return const Color(0xfff9fafb);
-                      }
-                      return Colors.white;
-                    },
+              height: 56,
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xffef4444), // rojo de alerta
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
                   ),
-                  shape: WidgetStateProperty.all(
-                    RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(8),
-                      side: const BorderSide(color: Color(0xffd1d5db)),
-                    ),
-                  ),
-                  padding: WidgetStateProperty.all(
-                    const EdgeInsets.symmetric(horizontal: 16),
-                  ),
+                  elevation: 2,
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
                 ),
                 onPressed: _callEmergency,
                 child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    const Icon(Icons.shield, color: Color(0xff2563eb), size: 20),
-                    const SizedBox(width: 12),
-                    Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: const [
-                        Text(
-                          'Emergencias',
-                          style: TextStyle(fontWeight: FontWeight.w600),
-                        ),
-                        SizedBox(height: 2),
-                        Text(
-                          '911',
-                          style: TextStyle(color: Color(0xff6b7280), fontSize: 12),
-                        ),
-                      ],
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: const [
+                    Icon(Icons.shield, size: 20),
+                    SizedBox(width: 10),
+                    Text(
+                      'Llamar al 911',
+                      style: TextStyle(
+                        fontWeight: FontWeight.w600,
+                        fontSize: 16,
+                      ),
                     ),
                   ],
                 ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -474,6 +474,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "8582d7f6fe14d2652b4c45c9b6c14c0b678c2af2d083a11b604caeba51930d79"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.16"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "7f2022359d4c099eea7df3fdf739f7d3d3b9faf3166fb1dd390775176e0b76cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.3"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   firebase_crashlytics: ^4.3.7
   quick_actions: ^1.1.0
   rate_my_app: ^2.3.1
+  url_launcher: ^6.2.5
   shared_preferences_android: ^2.4.10
   wakelock_partial_android: ^1.0.0
 


### PR DESCRIPTION
## Summary
- add a new `QuickCallSection` Flutter widget to show a quick 911 call option
- integrate `QuickCallSection` below the emergency panic button
- include `url_launcher` dependency
- ensure tapping the quick call card opens the external dialer
- replace deprecated `MaterialStateProperty` with `WidgetStateProperty`

## Testing
- `dart format lib/quick_call_section.dart lib/panic_screen.dart` *(fails: `bash: dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685844c9944c83208f86a2bc2af35484