### PR TITLE
Switch Android/iOS bundle id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Traccar Client app](https://www.traccar.org/client)
 
-[![Get it on Google Play](http://www.tananaev.com/badges/google-play.svg)](https://play.google.com/store/apps/details?id=org.traccar.client) [![Download on the App Store](http://www.tananaev.com/badges/app-store.svg)](https://itunes.apple.com/app/traccar-client/id843156974)
+[![Get it on Google Play](http://www.tananaev.com/badges/google-play.svg)](https://play.google.com/store/apps/details?id=org.dalquin.client) [![Download on the App Store](http://www.tananaev.com/badges/app-store.svg)](https://itunes.apple.com/app/traccar-client/id843156974)
 
 ## Overview
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    namespace = "org.traccar.client"
+    namespace = "org.dalquin.client"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = "27.0.12077973"
 
@@ -36,7 +36,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "org.traccar.client"
+        applicationId = "org.dalquin.client"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -10,7 +10,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:39016471396:android:b1c7194c699bfa25",
         "android_client_info": {
-          "package_name": "org.traccar.client"
+          "package_name": "org.dalquin.client"
         }
       },
       "oauth_client": [],
@@ -26,7 +26,7 @@
               "client_id": "39016471396-7mdutolor3h210bm9qmf60gp18lmmhnm.apps.googleusercontent.com",
               "client_type": 2,
               "ios_info": {
-                "bundle_id": "org.traccar.client.TraccarClient"
+                "bundle_id": "org.dalquin.client.TraccarClient"
               }
             }
           ]

--- a/android/app/src/main/kotlin/org/dalquin/client/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/dalquin/client/MainActivity.kt
@@ -1,4 +1,4 @@
-package org.traccar.client
+package org.dalquin.client
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -523,7 +523,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = org.traccar.client.TraccarClient;
+                                PRODUCT_BUNDLE_IDENTIFIER = org.dalquin.client.TraccarClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -707,7 +707,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = org.traccar.client.TraccarClient;
+                                PRODUCT_BUNDLE_IDENTIFIER = org.dalquin.client.TraccarClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -731,7 +731,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = org.traccar.client.TraccarClient;
+                                PRODUCT_BUNDLE_IDENTIFIER = org.dalquin.client.TraccarClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/GoogleService-Info.plist
+++ b/ios/Runner/GoogleService-Info.plist
@@ -13,7 +13,7 @@
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>org.traccar.client.TraccarClient</string>
+        <string>org.dalquin.client.TraccarClient</string>
 	<key>PROJECT_ID</key>
 	<string>traccar-client-app</string>
 	<key>STORAGE_BUCKET</key>

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -66,7 +66,7 @@ class DefaultFirebaseOptions {
     databaseURL: 'https://traccar-client-app.firebaseio.com',
     storageBucket: 'traccar-client-app.firebasestorage.app',
     iosClientId: '39016471396-7mdutolor3h210bm9qmf60gp18lmmhnm.apps.googleusercontent.com',
-    iosBundleId: 'org.traccar.client.TraccarClient',
+    iosBundleId: 'org.dalquin.client.TraccarClient',
   );
 
 }


### PR DESCRIPTION
## Summary
- adjust README package link to new id
- set Android namespace & applicationId to `org.dalquin.client`
- update google services config
- move MainActivity to new package
- update iOS bundle identifiers
- update Firebase options bundle id

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6859da62560483209db86007e6417f1a